### PR TITLE
FEATURE(meta): Add a conscience slots managment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ An Ansible role for install and configure meta0, meta1 and meta2. Specifically, 
 | `openio_meta_namespace` | `"OPENIO"` | Namespace |
 | `openio_meta_options` | `[]` | Specific options |
 | `openio_meta_serviceid` | `"0"` | ID in gridinit |
+| `openio_meta_slots` | `[meta0]` | The service's slot in conscience |
 | `openio_meta_version` | `latest` | Install a specific version |
 | `openio_meta_volume` | `"/var/lib/oio/sds/{{ openio_meta_namespace }}/{{ openio_meta_type }}-{{ openio_meta_serviceid }}"` | Path to store data |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,4 +32,8 @@ openio_meta_gridinit_file_prefix: ""
 #   meta2:
 #     port: 6021
 #     service_name: meta2
+openio_meta_slots:
+  "{{ [ openio_meta_type, openio_meta_type ~ '-' ~ openio_meta_location.split('.')[:-2] | join('-') ] \
+  if openio_meta_location.split('.') | length > 2 \
+  else [ openio_meta_type ] }}"
 ...

--- a/templates/watch-meta.yml.j2
+++ b/templates/watch-meta.yml.j2
@@ -14,4 +14,6 @@ stats:
   - {type: volume, path: {{ openio_meta_volume }}}
   - {type: meta}
   - {type: system}
+slots:
+  {{ openio_meta_slots | to_nice_yaml | indent(2) }}
 ...


### PR DESCRIPTION
 ##### ISSUE TYPE
- Feature

 ##### SUMMARY
Add slots for multisite deployments

 ##### SCOPE (skeleton only)
- meta

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Currently slots are unmanaged.
This commit add a default slot (servicetype's name).
For location superior to 2, a slot is added based on the first two locations

examples:
location:
  - host.id            slots => [meta]
  - site.host.id       slots => [meta, meta-site]
  - region.site.host.id  slots => [meta, meta-region-site]