### PR TITLE
CHANGE(meta): Disable health check on `meta1` at bootstrap

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,6 +79,7 @@
       failed_when:
         - _meta_check.rc != 0
         - "'PING OK' not in _meta_check.stdout"
+      when: openio_meta_type != 'meta1'
   when: openio_bootstrap | d(false)
 
 ...


### PR DESCRIPTION
 ##### SUMMARY

`meta1` doesn't bind port before it find a `meta0` in conscience

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION