### PR TITLE
CHANGE(meta): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ An Ansible role for install and configure meta0, meta1 and meta2. Specifically, 
 | `openio_meta_slots` | `[meta0]` | The service's slot in conscience |
 | `openio_meta_version` | `latest` | Install a specific version |
 | `openio_meta_volume` | `"/var/lib/oio/sds/{{ openio_meta_namespace }}/{{ openio_meta_type }}-{{ openio_meta_serviceid }}"` | Path to store data |
+| `openio_meta_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,8 @@ openio_meta_options: []
 openio_meta_location: "{{ openio_location_room | default ('') }}{{ openio_location_rack | default ('') }}\
   {{ openio_location_server | default (ansible_hostname ~ '.') }}{{ openio_meta_serviceid }}"
 openio_meta_provision_only: false
+openio_meta_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
+
 
 openio_meta_gridinit_dir: "/etc/gridinit.d/{{ openio_meta_namespace }}"
 openio_meta_gridinit_file_prefix: ""

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_meta_package_upgrade else 'present' }}"
   with_items: "{{ meta_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_meta_package_upgrade else 'present' }}"
   with_items: "{{ meta_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION