### PR TITLE
BUGFIX/MEDIUM(meta): Fix optimized check interval

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,8 +75,8 @@
     - name: check meta
       command: "oio-tool ping {{ openio_meta_bind_address }}:{{ openio_meta_bind_port }}"
       register: _meta_check
-      retries: 30
-      delay: 0.5
+      retries: 15
+      delay: 1
       until: _meta_check is success
       changed_when: false
       tags: configure


### PR DESCRIPTION
 ##### SUMMARY

When the strategy `mitogen_free` is used, the ssh connection is persitant.
The usage of delay below 1 seconde is an issue.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION